### PR TITLE
project_openldap: fix missing return values

### DIFF
--- a/coldfront/plugins/project_openldap/utils.py
+++ b/coldfront/plugins/project_openldap/utils.py
@@ -63,7 +63,7 @@ def add_members_to_openldap_posixgroup(dn, list_memberuids, write=True):
     * Should not raise any exceptions
     * returns `True` if skipped or successful, `False` if failed
     """
-    _ldap_write_wrapper(Connection.modify, dn, {"memberUid": [(MODIFY_ADD, list_memberuids)]}, write=write)
+    return _ldap_write_wrapper(Connection.modify, dn, {"memberUid": [(MODIFY_ADD, list_memberuids)]}, write=write)
 
 
 def remove_members_from_openldap_posixgroup(dn, list_memberuids, write=True):
@@ -73,7 +73,7 @@ def remove_members_from_openldap_posixgroup(dn, list_memberuids, write=True):
     * Should not raise any exceptions
     * returns `True` if skipped or successful, `False` if failed
     """
-    _ldap_write_wrapper(Connection.modify, dn, {"memberUid": [(MODIFY_DELETE, list_memberuids)]}, write=write)
+    return _ldap_write_wrapper(Connection.modify, dn, {"memberUid": [(MODIFY_DELETE, list_memberuids)]}, write=write)
 
 
 def add_per_project_ou_to_openldap(project_obj, dn, openldap_ou_description, write=True):
@@ -83,7 +83,7 @@ def add_per_project_ou_to_openldap(project_obj, dn, openldap_ou_description, wri
     * Should not raise any exceptions
     * returns `True` if skipped or successful, `False` if failed
     """
-    _ldap_write_wrapper(
+    return _ldap_write_wrapper(
         Connection.add,
         dn,
         ["top", "organizationalUnit"],
@@ -99,7 +99,7 @@ def add_posixgroup_to_openldap(dn, openldap_description, gid_int, write=True):
     * Should not raise any exceptions
     * returns `True` if skipped or successful, `False` if failed
     """
-    _ldap_write_wrapper(
+    return _ldap_write_wrapper(
         Connection.add,
         dn,
         "posixGroup",
@@ -116,7 +116,7 @@ def remove_dn_from_openldap(dn, write=True):
     * Should not raise any exceptions
     * returns `True` if skipped or successful, `False` if failed
     """
-    _ldap_write_wrapper(Connection.delete, dn, write=write)
+    return _ldap_write_wrapper(Connection.delete, dn, write=write)
 
 
 # Update the project title in OpenLDAP
@@ -127,7 +127,9 @@ def update_posixgroup_description_in_openldap(dn, openldap_description, write=Tr
     * Should not raise any exceptions
     * returns `True` if skipped or successful, `False` if failed
     """
-    _ldap_write_wrapper(Connection.modify, dn, {"description": [(MODIFY_REPLACE, [openldap_description])]}, write=write)
+    return _ldap_write_wrapper(
+        Connection.modify, dn, {"description": [(MODIFY_REPLACE, [openldap_description])]}, write=write
+    )
 
 
 # MOVE the project to an archive OU - defined as env var
@@ -138,7 +140,7 @@ def move_dn_in_openldap(current_dn, relative_dn, destination_ou, write=True):
     * Should not raise any exceptions
     * returns `True` if skipped or successful, `False` if failed
     """
-    _ldap_write_wrapper(Connection.modify_dn, current_dn, relative_dn, new_superior=destination_ou, write=write)
+    return _ldap_write_wrapper(Connection.modify_dn, current_dn, relative_dn, new_superior=destination_ou, write=write)
 
 
 def ldapsearch_check_project_dn(dn):


### PR DESCRIPTION
In the original code, the utils caught all exceptions and returned None, and the callers checked for exceptions that would never be raised. This is wrong since success cannot be determined from the utils and the callers' exception handlers create a false sense of security.

When I rewrote the utils, I wanted to be 100% compatible, so I still caught all exceptions. I intended to add a boolean return value so that success could be determined, but I forgot the `return` keyword. This patch adds the `return` keyword so that the boolean return value works as advertised in the docstrings. There aren't any conditionals checking this return value at this time.

Here is one dead exception handler: https://github.com/coldfront/coldfront/blob/b28aabdc676bc72ee047c7f5a36a693d04279798/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py#L365-L371

There are two ways to move forward:
1. remove the dead exception handlers and add error checking conditionals (https://github.com/coldfront/coldfront/pull/996)
2. stop catching exceptions in the utils and let the dead exception handlers work as expected (https://github.com/coldfront/coldfront/pull/997)

I prefer option 2. ~~Then the boolean return value can be repurposed to say whether or not the operation was skipped, and~~ the dead exception handlers will work as expected.

I would like to hold of on these future changes until I can write automated test cases.