### PR TITLE
Add FreeIPA offboarding helper to revoke group memberships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ColdFront Changelog
 
+## [Unreleased]
+
+- Add `freeipa/offboard.py` helper for capture-based group-membership revocation on user offboarding: `managed_groups_for_user`, `plan_offboard`, `remove_user_from_groups`, `add_user_to_groups`, a cross-allocation safeguard, and a django-q task entry point
+
 ## [1.1.8] - 2026-05-11
 
 - Add podman support [#733](https://github.com/coldfront/coldfront/pull/733)

--- a/coldfront/plugins/freeipa/offboard.py
+++ b/coldfront/plugins/freeipa/offboard.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Offboarding helpers: revoke a user's FreeIPA group memberships.
+
+The signal path (``tasks.remove_user_group``) derives the ``.rw``/``.ro`` suffix from
+the user's ProjectUser *role* and skips users whose role can no longer be resolved
+(e.g. a departed user whose ProjectUser was hard-deleted). Those users therefore keep
+their FreeIPA group membership — and their filesystem access — indefinitely.
+
+This module offboards a user by *capture-and-attempt*, not by role: it derives the set
+of managed groups from the user's allocations (the ``freeipa_group`` allocation attribute
+value plus ``.rw``/``.ro`` — the same construction ``tasks.add_user_group`` uses), drops
+any group the user still holds via another Active allocation, and removes the rest.
+
+Both IPA-realm (internal) and AD-trust (external) members are supported; external
+detection is by email domain via the ``FREEIPA_EXTERNAL_DOMAIN`` setting, and
+``_remove_one`` attempts both member types so a misclassification is self-correcting.
+
+The ``freeipa_group`` attribute value is treated as an opaque group base name; any
+site-specific segments it carries (e.g. ``.e``/``.e.d`` markers for external/domain
+groups) are preserved as-is, and ``.rw``/``.ro`` is appended. For AD-trust external
+members there is no reverse "what groups is this user in" lookup, so we do not narrow by
+current membership — we attempt ``group_remove_member`` on each candidate and treat *not
+a member* / *group not found* as harmless no-ops. The API result is the authoritative
+record for audit and backout.
+
+This module deliberately has no import-time side effects and does NOT import
+``coldfront.plugins.freeipa.tasks`` (which runs a semaphore read, a sleep and a possible
+``sys.exit`` at import).
+"""
+
+import logging
+
+from coldfront.core.allocation.models import Allocation, AllocationUser
+from coldfront.core.utils.common import import_from_settings
+from coldfront.plugins.freeipa.utils import (
+    UNIX_GROUP_ATTRIBUTE_NAME,
+    AlreadyMemberError,
+    NotMemberError,
+    check_ipa_group_error,
+    ipa_bootstrap,
+)
+
+logger = logging.getLogger(__name__)
+
+STATUS_ACTIVE = "Active"
+GROUP_SUFFIXES = (".rw", ".ro")
+
+# Email domain whose users join FreeIPA groups as AD-trust external members
+# (``ipaexternalmember``). Empty (the default) means every user is treated as an
+# internal IPA-realm member; ``_remove_one`` falls back to the other member type anyway.
+FREEIPA_EXTERNAL_DOMAIN = import_from_settings("FREEIPA_EXTERNAL_DOMAIN", "")
+
+
+def is_external_member(user):
+    """True if the user joins FreeIPA groups as an AD-trust external member.
+
+    AD-trust domain users are external members (``ipaexternalmember``); IPA-realm users
+    are internal (``user=[...]``). See the FREEIPA_EXTERNAL_DOMAIN setting. Matches on the
+    email domain (not a substring) so e.g. ``x@notexample.org`` is not misread; the
+    attempt-both-modes fallback in ``_remove_one`` covers any residual mismatch.
+    """
+    email = (user.email or "").lower()
+    return email.endswith("@" + FREEIPA_EXTERNAL_DOMAIN.lower())
+
+
+def _allocation_base_groups(allocation):
+    """The ``freeipa_group`` attribute values on an allocation (already carry .e/.e.d)."""
+    return allocation.get_attribute_list(UNIX_GROUP_ATTRIBUTE_NAME)
+
+
+def _suffixed(base_values):
+    return {f"{value}{suffix}" for value in base_values for suffix in GROUP_SUFFIXES}
+
+
+def managed_groups_for_user(user):
+    """All ``<freeipa_group>.{rw,ro}`` groups derived from any allocation the user is on.
+
+    Both suffixes are included because an offboarded user's role may no longer be
+    resolvable, so we cannot know which they held; removing the other suffix is a no-op.
+    """
+    base_values = set()
+    for au in AllocationUser.objects.filter(user=user).select_related("allocation"):
+        base_values.update(_allocation_base_groups(au.allocation))
+    return _suffixed(base_values)
+
+
+def groups_to_keep(user, exclude_allocation_pk=None):
+    """Groups the user still legitimately holds via an Active allocation elsewhere.
+
+    Mirrors the cross-allocation safeguard in ``tasks.remove_user_group``: never remove a
+    group the user retains through another live membership.
+    """
+    keep_allocations = Allocation.objects.filter(
+        allocationuser__user=user,
+        allocationuser__status__name=STATUS_ACTIVE,
+        status__name=STATUS_ACTIVE,
+        allocationattribute__allocation_attribute_type__name=UNIX_GROUP_ATTRIBUTE_NAME,
+    ).distinct()
+    if exclude_allocation_pk is not None:
+        keep_allocations = keep_allocations.exclude(pk=exclude_allocation_pk)
+
+    base_values = set()
+    for a in keep_allocations:
+        base_values.update(_allocation_base_groups(a))
+    return _suffixed(base_values)
+
+
+def plan_offboard(user, exclude_allocation_pk=None):
+    """Compute ``(target_groups, kept_groups)`` for a user, applying the safeguard.
+
+    ``target_groups`` is sorted. Targets are NOT narrowed by current membership (external
+    members have no reverse lookup); removal of a non-membership is a no-op.
+    """
+    candidates = managed_groups_for_user(user)
+    kept = groups_to_keep(user, exclude_allocation_pk=exclude_allocation_pk)
+    return sorted(candidates - kept), kept
+
+
+def _remove_one(group, username, external):
+    """Remove a member, trying the other member type on NotMemberError.
+
+    Returns 'external'/'internal' on success, 'not-member' if in neither, 'no-group' if
+    the group does not exist. Raises on any other API error.
+    """
+    from ipalib import api, errors
+
+    order = ("external", "internal") if external else ("internal", "external")
+    for mode in order:
+        try:
+            if mode == "external":
+                res = api.Command.group_remove_member(group, ipaexternalmember=(username,))
+            else:
+                res = api.Command.group_remove_member(group, user=[username])
+            check_ipa_group_error(res)
+            return mode
+        except NotMemberError:
+            continue
+        except errors.NotFound:
+            return "no-group"
+    return "not-member"
+
+
+def _add_one(group, username, external):
+    """Re-add a member (backout). Returns 'external'/'internal', 'already-member', or
+    'no-group'. Raises on any other API error."""
+    from ipalib import api, errors
+
+    try:
+        if external:
+            res = api.Command.group_add_member(group, ipaexternalmember=(username,))
+        else:
+            res = api.Command.group_add_member(group, user=[username])
+        check_ipa_group_error(res)
+        return "external" if external else "internal"
+    except AlreadyMemberError:
+        return "already-member"
+    except errors.NotFound:
+        return "no-group"
+
+
+def remove_user_from_groups(user, groups, *, dry_run, bootstrap=True):
+    """Remove ``user`` from each group. Returns a list of per-group result records.
+
+    Never raises: a single group's API failure is recorded and the rest proceed. result
+    is 'would-remove' | 'removed:<mode>' | 'not-member' | 'no-group' | 'error'.
+    """
+    external = is_external_member(user)
+    records = []
+    if not dry_run and bootstrap:
+        ipa_bootstrap()
+
+    for g in groups:
+        rec = {"group": g, "action": "remove", "user": user.username, "external": external, "dry_run": dry_run}
+        if dry_run:
+            rec["result"] = "would-remove"
+            records.append(rec)
+            continue
+        try:
+            mode = _remove_one(g, user.username, external)
+            rec["result"] = mode if mode in ("not-member", "no-group") else f"removed:{mode}"
+            if mode not in ("not-member", "no-group"):
+                logger.info("Removed %s from FreeIPA group %s (%s)", user.username, g, mode)
+        except Exception as e:
+            rec["result"] = "error"
+            rec["error"] = str(e)
+            logger.error("Failed removing %s from group %s: %s", user.username, g, e)
+        records.append(rec)
+    return records
+
+
+def add_user_to_groups(user, groups, *, dry_run, external=None, bootstrap=True):
+    """Re-add ``user`` to each group (backout of a removal). Mirrors remove semantics.
+
+    ``external`` overrides the member-type heuristic — backout passes the mode the
+    original removal actually used, so a fallback removal is reversed faithfully.
+    """
+    if external is None:
+        external = is_external_member(user)
+    records = []
+    if not dry_run and bootstrap:
+        ipa_bootstrap()
+
+    for g in groups:
+        rec = {"group": g, "action": "add", "user": user.username, "external": external, "dry_run": dry_run}
+        if dry_run:
+            rec["result"] = "would-add"
+            records.append(rec)
+            continue
+        try:
+            mode = _add_one(g, user.username, external)
+            rec["result"] = mode if mode in ("already-member", "no-group") else f"added:{mode}"
+            if mode not in ("already-member", "no-group"):
+                logger.info("Re-added %s to FreeIPA group %s (%s)", user.username, g, mode)
+        except Exception as e:
+            rec["result"] = "error"
+            rec["error"] = str(e)
+            logger.error("Failed adding %s to group %s: %s", user.username, g, e)
+        records.append(rec)
+    return records
+
+
+def offboard_user_groups_task(user_pk):
+    """django-q entry point: revoke one user's FreeIPA groups (execute mode).
+
+    Enqueued from the ProjectUser-removal cascade so the FreeIPA work runs in the
+    qcluster worker, not the web request. Never raises. The cross-allocation safeguard in
+    ``plan_offboard`` keeps any group the user still holds via an Active allocation.
+    """
+    from django.contrib.auth.models import User
+
+    try:
+        user = User.objects.get(pk=user_pk)
+    except User.DoesNotExist:
+        logger.warning("offboard_user_groups_task: user pk=%s no longer exists", user_pk)
+        return
+    try:
+        targets, kept = plan_offboard(user)
+        logger.info(
+            "offboard_user_groups_task: %s — %d group(s) to revoke, %d kept (active elsewhere)",
+            user.username,
+            len(targets),
+            len(kept),
+        )
+        if targets:
+            remove_user_from_groups(user, targets, dry_run=False)
+    except Exception as e:
+        logger.error("offboard_user_groups_task failed for %s: %s", user.username, e)

--- a/coldfront/plugins/freeipa/offboard.py
+++ b/coldfront/plugins/freeipa/offboard.py
@@ -4,24 +4,29 @@
 
 """Offboarding helpers: revoke a user's FreeIPA group memberships.
 
-The signal path (``tasks.remove_user_group``) derives the ``.rw``/``.ro`` suffix from
-the user's ProjectUser *role* and skips users whose role can no longer be resolved
-(e.g. a departed user whose ProjectUser was hard-deleted). Those users therefore keep
-their FreeIPA group membership — and their filesystem access — indefinitely.
+``tasks.remove_user_group`` removes a user from their groups when their
+``AllocationUser`` is set to ``Removed``, but it is only ever called as a side effect of
+that status change. A user whose ``ProjectUser`` (and so, by the cascade, their
+``AllocationUser``) is hard-deleted rather than status-flipped never goes through that
+path, so they keep their FreeIPA group membership — and the access it grants —
+indefinitely.
 
-This module offboards a user by *capture-and-attempt*, not by role: it derives the set
-of managed groups from the user's allocations (the ``freeipa_group`` allocation attribute
-value plus ``.rw``/``.ro`` — the same construction ``tasks.add_user_group`` uses), drops
-any group the user still holds via another Active allocation, and removes the rest.
+This module offboards a user by *capture-and-attempt* instead: it derives the set of
+groups the user's allocations grant, drops any group the user still holds via another
+Active allocation (the same cross-allocation safeguard as ``tasks.remove_user_group``),
+and removes the rest.
+
+By default a group is the literal ``freeipa_group`` allocation attribute value, exactly
+as ``tasks.add_user_group``/``remove_user_group`` use it. Deployments where one
+allocation attribute value maps to more than one actual FreeIPA group — for example a
+role-based naming convention layered on top by a downstream plugin — can pass
+``group_names_for_allocation`` to every public function here to override the mapping.
 
 Both IPA-realm (internal) and AD-trust (external) members are supported; external
-detection is by email domain via the ``FREEIPA_EXTERNAL_DOMAIN`` setting, and
-``_remove_one`` attempts both member types so a misclassification is self-correcting.
-
-The ``freeipa_group`` attribute value is treated as an opaque group base name; any
-site-specific segments it carries (e.g. ``.e``/``.e.d`` markers for external/domain
-groups) are preserved as-is, and ``.rw``/``.ro`` is appended. For AD-trust external
-members there is no reverse "what groups is this user in" lookup, so we do not narrow by
+detection is by email domain via the optional ``FREEIPA_EXTERNAL_DOMAIN`` setting
+(unset → every user is treated as internal), and ``_remove_one``/``_add_one`` attempt
+both member types so a misclassification is self-correcting. For external members there
+is no reverse "what groups is this user in" lookup, so targets are not narrowed by
 current membership — we attempt ``group_remove_member`` on each candidate and treat *not
 a member* / *group not found* as harmless no-ops. The API result is the authoritative
 record for audit and backout.
@@ -46,7 +51,6 @@ from coldfront.plugins.freeipa.utils import (
 logger = logging.getLogger(__name__)
 
 STATUS_ACTIVE = "Active"
-GROUP_SUFFIXES = (".rw", ".ro")
 
 # Email domain whose users join FreeIPA groups as AD-trust external members
 # (``ipaexternalmember``). Empty (the default) means every user is treated as an
@@ -67,32 +71,37 @@ def is_external_member(user):
 
 
 def _allocation_base_groups(allocation):
-    """The ``freeipa_group`` attribute values on an allocation (already carry .e/.e.d)."""
+    """Default ``group_names_for_allocation``: the raw ``freeipa_group`` attribute
+    value(s) on an allocation, unchanged -- the same names ``tasks.add_user_group`` and
+    ``tasks.remove_user_group`` use."""
     return allocation.get_attribute_list(UNIX_GROUP_ATTRIBUTE_NAME)
 
 
-def _suffixed(base_values):
-    return {f"{value}{suffix}" for value in base_values for suffix in GROUP_SUFFIXES}
+def managed_groups_for_user(user, *, group_names_for_allocation=None):
+    """All FreeIPA groups derived from any allocation the user is on.
 
-
-def managed_groups_for_user(user):
-    """All ``<freeipa_group>.{rw,ro}`` groups derived from any allocation the user is on.
-
-    Both suffixes are included because an offboarded user's role may no longer be
-    resolvable, so we cannot know which they held; removing the other suffix is a no-op.
+    ``group_names_for_allocation`` is called once per allocation and must return an
+    iterable of group names; it defaults to the literal ``freeipa_group`` attribute
+    value(s) (see ``_allocation_base_groups``). Override it for a deployment where one
+    attribute value maps to more than one actual group.
     """
-    base_values = set()
+    if group_names_for_allocation is None:
+        group_names_for_allocation = _allocation_base_groups
+    names = set()
     for au in AllocationUser.objects.filter(user=user).select_related("allocation"):
-        base_values.update(_allocation_base_groups(au.allocation))
-    return _suffixed(base_values)
+        names.update(group_names_for_allocation(au.allocation))
+    return names
 
 
-def groups_to_keep(user, exclude_allocation_pk=None):
+def groups_to_keep(user, exclude_allocation_pk=None, *, group_names_for_allocation=None):
     """Groups the user still legitimately holds via an Active allocation elsewhere.
 
     Mirrors the cross-allocation safeguard in ``tasks.remove_user_group``: never remove a
-    group the user retains through another live membership.
+    group the user retains through another live membership. See ``managed_groups_for_user``
+    for ``group_names_for_allocation``.
     """
+    if group_names_for_allocation is None:
+        group_names_for_allocation = _allocation_base_groups
     keep_allocations = Allocation.objects.filter(
         allocationuser__user=user,
         allocationuser__status__name=STATUS_ACTIVE,
@@ -102,20 +111,23 @@ def groups_to_keep(user, exclude_allocation_pk=None):
     if exclude_allocation_pk is not None:
         keep_allocations = keep_allocations.exclude(pk=exclude_allocation_pk)
 
-    base_values = set()
+    names = set()
     for a in keep_allocations:
-        base_values.update(_allocation_base_groups(a))
-    return _suffixed(base_values)
+        names.update(group_names_for_allocation(a))
+    return names
 
 
-def plan_offboard(user, exclude_allocation_pk=None):
+def plan_offboard(user, exclude_allocation_pk=None, *, group_names_for_allocation=None):
     """Compute ``(target_groups, kept_groups)`` for a user, applying the safeguard.
 
     ``target_groups`` is sorted. Targets are NOT narrowed by current membership (external
-    members have no reverse lookup); removal of a non-membership is a no-op.
+    members have no reverse lookup); removal of a non-membership is a no-op. See
+    ``managed_groups_for_user`` for ``group_names_for_allocation``.
     """
-    candidates = managed_groups_for_user(user)
-    kept = groups_to_keep(user, exclude_allocation_pk=exclude_allocation_pk)
+    candidates = managed_groups_for_user(user, group_names_for_allocation=group_names_for_allocation)
+    kept = groups_to_keep(
+        user, exclude_allocation_pk=exclude_allocation_pk, group_names_for_allocation=group_names_for_allocation
+    )
     return sorted(candidates - kept), kept
 
 
@@ -222,12 +234,13 @@ def add_user_to_groups(user, groups, *, dry_run, external=None, bootstrap=True):
     return records
 
 
-def offboard_user_groups_task(user_pk):
+def offboard_user_groups_task(user_pk, *, group_names_for_allocation=None):
     """django-q entry point: revoke one user's FreeIPA groups (execute mode).
 
     Enqueued from the ProjectUser-removal cascade so the FreeIPA work runs in the
     qcluster worker, not the web request. Never raises. The cross-allocation safeguard in
-    ``plan_offboard`` keeps any group the user still holds via an Active allocation.
+    ``plan_offboard`` keeps any group the user still holds via an Active allocation. See
+    ``managed_groups_for_user`` for ``group_names_for_allocation``.
     """
     from django.contrib.auth.models import User
 
@@ -237,7 +250,7 @@ def offboard_user_groups_task(user_pk):
         logger.warning("offboard_user_groups_task: user pk=%s no longer exists", user_pk)
         return
     try:
-        targets, kept = plan_offboard(user)
+        targets, kept = plan_offboard(user, group_names_for_allocation=group_names_for_allocation)
         logger.info(
             "offboard_user_groups_task: %s — %d group(s) to revoke, %d kept (active elsewhere)",
             user.username,

--- a/coldfront/plugins/freeipa/tests/test_offboard.py
+++ b/coldfront/plugins/freeipa/tests/test_offboard.py
@@ -1,0 +1,469 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Unit tests for freeipa/offboard.py."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# IPA stubs — ipalib and freeipa utils both require IPA to be installed and
+# configured. Stub them out so tests run without an IPA enrolment.
+# ---------------------------------------------------------------------------
+
+
+# Concrete exception classes so except-clauses in offboard.py work correctly.
+class _NotMemberError(Exception):
+    pass
+
+
+class _AlreadyMemberError(Exception):
+    pass
+
+
+_ipa_stub = MagicMock()
+_ipa_errors_stub = MagicMock()
+# Make errors.NotFound a concrete exception so offboard._remove_one can catch it.
+_ipa_errors_stub.NotFound = type("NotFound", (Exception,), {})
+# `from ipalib import errors` resolves the attribute on the ipalib module, so point
+# it at the same stub that carries the concrete NotFound class.
+_ipa_stub.errors = _ipa_errors_stub
+sys.modules.setdefault("ipalib", _ipa_stub)
+sys.modules.setdefault("ipalib.errors", _ipa_errors_stub)
+
+
+def _fake_check_ipa_group_error(res):
+    """Faithful re-implementation of utils.check_ipa_group_error.
+
+    Mirrors the real logic (utils.py) so the real ``_remove_one``/``_add_one`` exception
+    paths are exercised rather than stubbed away. Raises the same _NotMemberError /
+    _AlreadyMemberError that offboard.py imports from this stubbed utils module.
+    """
+    if not res:
+        raise ValueError("Missing FreeIPA response")
+    if res["completed"] == 1:
+        return
+    try:
+        err_msg = res["failed"]["member"]["user"][0][1]
+    except (KeyError, IndexError):
+        try:
+            err_msg = res["failed"]["member"]["group"][0][1]
+        except (KeyError, IndexError):
+            err_msg = None
+    if err_msg == "This entry is already a member":
+        raise _AlreadyMemberError(err_msg)
+    if err_msg == "This entry is not a member":
+        raise _NotMemberError(err_msg)
+    raise Exception(err_msg)
+
+
+# freeipa utils reads required FreeIPA Django settings at import time.  Stub
+# the module so tests can load offboard.py in any environment.
+_utils_stub = MagicMock()
+_utils_stub.FREEIPA_EXTERNAL_DOMAIN = "example.org"
+_utils_stub.UNIX_GROUP_ATTRIBUTE_NAME = "freeipa_group"
+_utils_stub.AlreadyMemberError = _AlreadyMemberError
+_utils_stub.NotMemberError = _NotMemberError
+_utils_stub.check_ipa_group_error = _fake_check_ipa_group_error
+_utils_stub.ipa_bootstrap = MagicMock()
+sys.modules["coldfront.plugins.freeipa.utils"] = _utils_stub
+
+
+def _completed():
+    return {"completed": 1}
+
+
+def _not_member():
+    return {"completed": 0, "failed": {"member": {"user": [["x", "This entry is not a member"]]}}}
+
+
+def _already_member():
+    return {"completed": 0, "failed": {"member": {"user": [["x", "This entry is already a member"]]}}}
+
+
+from django.test import TestCase  # noqa: E402
+
+from coldfront.core.test_helpers.factories import (  # noqa: E402
+    AAttributeTypeFactory,
+    AllocationAttributeFactory,
+    AllocationAttributeTypeFactory,
+    AllocationFactory,
+    AllocationStatusChoiceFactory,
+    AllocationUserFactory,
+    AllocationUserStatusChoiceFactory,
+    ProjectFactory,
+    UserFactory,
+)
+
+FREEIPA_GROUP_ATTR = "freeipa_group"
+
+
+def _make_allocation(user, group_value, alloc_status="Active", au_status="Active"):
+    """Create an allocation with a freeipa_group attribute and an AllocationUser."""
+    status = AllocationStatusChoiceFactory(name=alloc_status)
+    alloc = AllocationFactory(
+        project=ProjectFactory(),
+        status=status,
+    )
+    attr_type = AAttributeTypeFactory(name="Text")
+    alloc_attr_type = AllocationAttributeTypeFactory(
+        name=FREEIPA_GROUP_ATTR,
+        attribute_type=attr_type,
+    )
+    AllocationAttributeFactory(
+        allocation_attribute_type=alloc_attr_type,
+        allocation=alloc,
+        value=group_value,
+    )
+    au_status_obj = AllocationUserStatusChoiceFactory(name=au_status)
+    AllocationUserFactory(allocation=alloc, user=user, status=au_status_obj)
+    return alloc
+
+
+class IsExternalMemberTest(TestCase):
+    def setUp(self):
+        self.patcher = patch(
+            "coldfront.plugins.freeipa.offboard.FREEIPA_EXTERNAL_DOMAIN",
+            "example.org",
+        )
+        self.patcher.start()
+        from coldfront.plugins.freeipa import offboard
+
+        self.offboard = offboard
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_external_email(self):
+        u = UserFactory(email="alice@example.org")
+        self.assertTrue(self.offboard.is_external_member(u))
+
+    def test_internal_email(self):
+        u = UserFactory(email="bob@ipa.example.org")
+        self.assertFalse(self.offboard.is_external_member(u))
+
+    def test_subdomain_not_misread(self):
+        u = UserFactory(email="carol@notexample.org")
+        self.assertFalse(self.offboard.is_external_member(u))
+
+    def test_blank_email(self):
+        u = UserFactory(email="")
+        self.assertFalse(self.offboard.is_external_member(u))
+
+
+class ManagedGroupsForUserTest(TestCase):
+    def test_no_allocations(self):
+        from coldfront.plugins.freeipa.offboard import managed_groups_for_user
+
+        u = UserFactory()
+        self.assertEqual(managed_groups_for_user(u), set())
+
+    def test_groups_from_single_allocation(self):
+        from coldfront.plugins.freeipa.offboard import managed_groups_for_user
+
+        u = UserFactory()
+        _make_allocation(u, "proj1.e.d")
+        result = managed_groups_for_user(u)
+        self.assertEqual(result, {"proj1.e.d.rw", "proj1.e.d.ro"})
+
+    def test_dedup_across_allocations(self):
+        from coldfront.plugins.freeipa.offboard import managed_groups_for_user
+
+        u = UserFactory()
+        _make_allocation(u, "proj1.e.d")
+        _make_allocation(u, "proj1.e.d")  # same base, second allocation
+        result = managed_groups_for_user(u)
+        self.assertEqual(result, {"proj1.e.d.rw", "proj1.e.d.ro"})
+
+    def test_multiple_allocations(self):
+        from coldfront.plugins.freeipa.offboard import managed_groups_for_user
+
+        u = UserFactory()
+        _make_allocation(u, "projA.e.d")
+        _make_allocation(u, "projB.e")
+        result = managed_groups_for_user(u)
+        self.assertIn("projA.e.d.rw", result)
+        self.assertIn("projB.e.ro", result)
+
+
+class GroupsToKeepTest(TestCase):
+    def test_active_allocation_elsewhere_kept(self):
+        from coldfront.plugins.freeipa.offboard import groups_to_keep
+
+        u = UserFactory()
+        _make_allocation(u, "live.e.d", alloc_status="Active", au_status="Active")
+        result = groups_to_keep(u)
+        self.assertIn("live.e.d.rw", result)
+        self.assertIn("live.e.d.ro", result)
+
+    def test_removed_au_not_kept(self):
+        from coldfront.plugins.freeipa.offboard import groups_to_keep
+
+        u = UserFactory()
+        _make_allocation(u, "gone.e.d", alloc_status="Active", au_status="Removed")
+        result = groups_to_keep(u)
+        self.assertNotIn("gone.e.d.rw", result)
+
+    def test_inactive_allocation_not_kept(self):
+        from coldfront.plugins.freeipa.offboard import groups_to_keep
+
+        u = UserFactory()
+        _make_allocation(u, "expired.e.d", alloc_status="Expired", au_status="Active")
+        result = groups_to_keep(u)
+        self.assertNotIn("expired.e.d.rw", result)
+
+    def test_exclude_allocation_pk(self):
+        from coldfront.plugins.freeipa.offboard import groups_to_keep
+
+        u = UserFactory()
+        alloc = _make_allocation(u, "proj.e.d", alloc_status="Active", au_status="Active")
+        result = groups_to_keep(u, exclude_allocation_pk=alloc.pk)
+        self.assertNotIn("proj.e.d.rw", result)
+
+
+class PlanOffboardTest(TestCase):
+    def test_all_targets_when_no_active_elsewhere(self):
+        from coldfront.plugins.freeipa.offboard import plan_offboard
+
+        u = UserFactory()
+        _make_allocation(u, "proj.e.d", alloc_status="Active", au_status="Removed")
+        targets, kept = plan_offboard(u)
+        self.assertIn("proj.e.d.rw", targets)
+        self.assertEqual(len(kept), 0)
+
+    def test_kept_excludes_from_targets(self):
+        from coldfront.plugins.freeipa.offboard import plan_offboard
+
+        u = UserFactory()
+        _make_allocation(u, "proj.e.d", alloc_status="Active", au_status="Active")
+        targets, kept = plan_offboard(u)
+        self.assertNotIn("proj.e.d.rw", targets)
+        self.assertIn("proj.e.d.rw", kept)
+
+    def test_targets_sorted(self):
+        from coldfront.plugins.freeipa.offboard import plan_offboard
+
+        u = UserFactory()
+        _make_allocation(u, "beta.e", alloc_status="Active", au_status="Removed")
+        _make_allocation(u, "alpha.e", alloc_status="Active", au_status="Removed")
+        targets, _ = plan_offboard(u)
+        self.assertEqual(targets, sorted(targets))
+
+
+class RemoveUserFromGroupsTest(TestCase):
+    def test_dry_run_no_api_call(self):
+        from coldfront.plugins.freeipa.offboard import remove_user_from_groups
+
+        u = UserFactory(username="alice")
+        with patch("coldfront.plugins.freeipa.offboard.ipa_bootstrap") as mock_boot:
+            records = remove_user_from_groups(u, ["proj.e.d.rw"], dry_run=True)
+        mock_boot.assert_not_called()
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["result"], "would-remove")
+        self.assertEqual(records[0]["action"], "remove")
+        self.assertEqual(records[0]["user"], "alice")
+
+    def test_execute_success_external(self):
+        from coldfront.plugins.freeipa.offboard import remove_user_from_groups
+
+        u = UserFactory(username="alice", email="alice@example.org")
+        with (
+            patch("coldfront.plugins.freeipa.offboard.ipa_bootstrap"),
+            patch("coldfront.plugins.freeipa.offboard.FREEIPA_EXTERNAL_DOMAIN", "example.org"),
+            patch("coldfront.plugins.freeipa.offboard._remove_one", return_value="external") as mock_rm,
+        ):
+            records = remove_user_from_groups(u, ["proj.e.d.rw"], dry_run=False)
+        mock_rm.assert_called_once_with("proj.e.d.rw", "alice", True)
+        self.assertEqual(records[0]["result"], "removed:external")
+
+    def test_execute_not_member_noop(self):
+        from coldfront.plugins.freeipa.offboard import remove_user_from_groups
+
+        u = UserFactory(username="bob", email="bob@ipa.example.org")
+        with (
+            patch("coldfront.plugins.freeipa.offboard.ipa_bootstrap"),
+            patch("coldfront.plugins.freeipa.offboard.FREEIPA_EXTERNAL_DOMAIN", "example.org"),
+            patch("coldfront.plugins.freeipa.offboard._remove_one", return_value="not-member"),
+        ):
+            records = remove_user_from_groups(u, ["proj.e.d.rw"], dry_run=False)
+        self.assertEqual(records[0]["result"], "not-member")
+
+    def test_execute_no_group_noop(self):
+        from coldfront.plugins.freeipa.offboard import remove_user_from_groups
+
+        u = UserFactory(username="carol", email="carol@ipa.example.org")
+        with (
+            patch("coldfront.plugins.freeipa.offboard.ipa_bootstrap"),
+            patch("coldfront.plugins.freeipa.offboard.FREEIPA_EXTERNAL_DOMAIN", "example.org"),
+            patch("coldfront.plugins.freeipa.offboard._remove_one", return_value="no-group"),
+        ):
+            records = remove_user_from_groups(u, ["ghost.rw"], dry_run=False)
+        self.assertEqual(records[0]["result"], "no-group")
+
+    def test_execute_api_error_never_raises(self):
+        from coldfront.plugins.freeipa.offboard import remove_user_from_groups
+
+        u = UserFactory(username="dave", email="dave@ipa.example.org")
+        with (
+            patch("coldfront.plugins.freeipa.offboard.ipa_bootstrap"),
+            patch("coldfront.plugins.freeipa.offboard.FREEIPA_EXTERNAL_DOMAIN", "example.org"),
+            patch("coldfront.plugins.freeipa.offboard._remove_one", side_effect=RuntimeError("timeout")),
+        ):
+            records = remove_user_from_groups(u, ["proj.rw"], dry_run=False)
+        self.assertEqual(records[0]["result"], "error")
+        self.assertIn("timeout", records[0]["error"])
+
+
+class AddUserToGroupsTest(TestCase):
+    def test_dry_run(self):
+        from coldfront.plugins.freeipa.offboard import add_user_to_groups
+
+        u = UserFactory(username="alice")
+        records = add_user_to_groups(u, ["proj.rw"], dry_run=True)
+        self.assertEqual(records[0]["result"], "would-add")
+
+    def test_already_member(self):
+        from coldfront.plugins.freeipa.offboard import add_user_to_groups
+
+        u = UserFactory(username="bob", email="bob@ipa.example.org")
+        with (
+            patch("coldfront.plugins.freeipa.offboard.ipa_bootstrap"),
+            patch("coldfront.plugins.freeipa.offboard.FREEIPA_EXTERNAL_DOMAIN", "example.org"),
+            patch("coldfront.plugins.freeipa.offboard._add_one", return_value="already-member"),
+        ):
+            records = add_user_to_groups(u, ["proj.rw"], dry_run=False)
+        self.assertEqual(records[0]["result"], "already-member")
+
+    def test_success_external_override(self):
+        from coldfront.plugins.freeipa.offboard import add_user_to_groups
+
+        u = UserFactory(username="carol", email="carol@ipa.example.org")
+        with (
+            patch("coldfront.plugins.freeipa.offboard.ipa_bootstrap"),
+            patch("coldfront.plugins.freeipa.offboard.FREEIPA_EXTERNAL_DOMAIN", "example.org"),
+            patch("coldfront.plugins.freeipa.offboard._add_one", return_value="external") as mock_add,
+        ):
+            records = add_user_to_groups(u, ["proj.rw"], dry_run=False, external=True)
+        mock_add.assert_called_once_with("proj.rw", "carol", True)
+        self.assertEqual(records[0]["result"], "added:external")
+
+
+class OffboardUserGroupsTaskTest(TestCase):
+    def test_user_not_found_no_raise(self):
+        from coldfront.plugins.freeipa.offboard import offboard_user_groups_task
+
+        with patch("coldfront.plugins.freeipa.offboard.plan_offboard") as mock_plan:
+            offboard_user_groups_task(user_pk=999999)
+        mock_plan.assert_not_called()
+
+    def test_normal_path_calls_remove(self):
+        from coldfront.plugins.freeipa.offboard import offboard_user_groups_task
+
+        u = UserFactory()
+        with (
+            patch(
+                "coldfront.plugins.freeipa.offboard.plan_offboard", return_value=(["proj.e.d.rw"], set())
+            ) as mock_plan,
+            patch("coldfront.plugins.freeipa.offboard.remove_user_from_groups") as mock_rm,
+        ):
+            offboard_user_groups_task(user_pk=u.pk)
+        mock_plan.assert_called_once_with(u)
+        mock_rm.assert_called_once_with(u, ["proj.e.d.rw"], dry_run=False)
+
+    def test_empty_targets_no_remove_call(self):
+        from coldfront.plugins.freeipa.offboard import offboard_user_groups_task
+
+        u = UserFactory()
+        with (
+            patch("coldfront.plugins.freeipa.offboard.plan_offboard", return_value=([], {"proj.e.d.rw"})),
+            patch("coldfront.plugins.freeipa.offboard.remove_user_from_groups") as mock_rm,
+        ):
+            offboard_user_groups_task(user_pk=u.pk)
+        mock_rm.assert_not_called()
+
+    def test_exception_never_raises(self):
+        from coldfront.plugins.freeipa.offboard import offboard_user_groups_task
+
+        u = UserFactory()
+        with patch("coldfront.plugins.freeipa.offboard.plan_offboard", side_effect=RuntimeError("oops")):
+            offboard_user_groups_task(user_pk=u.pk)  # must not raise
+
+
+class RemoveOneRealTest(TestCase):
+    """Exercise the REAL _remove_one — only the ipalib api boundary is mocked.
+
+    Covers the FreeIPA call construction, the external->internal fallback, the
+    check_ipa_group_error exception handling, and the errors.NotFound path.
+    """
+
+    def setUp(self):
+        from coldfront.plugins.freeipa import offboard
+
+        self.offboard = offboard
+        self.cmd = MagicMock()
+        _ipa_stub.api.Command = self.cmd
+        self.addCleanup(lambda: setattr(_ipa_stub.api, "Command", MagicMock()))
+
+    def test_external_success(self):
+        self.cmd.group_remove_member.return_value = _completed()
+        result = self.offboard._remove_one("grp.rw", "alice", external=True)
+        self.assertEqual(result, "external")
+        self.cmd.group_remove_member.assert_called_once_with("grp.rw", ipaexternalmember=("alice",))
+
+    def test_internal_success(self):
+        self.cmd.group_remove_member.return_value = _completed()
+        result = self.offboard._remove_one("grp.rw", "bob", external=False)
+        self.assertEqual(result, "internal")
+        self.cmd.group_remove_member.assert_called_once_with("grp.rw", user=["bob"])
+
+    def test_external_falls_back_to_internal(self):
+        # External attempt reports not-a-member; internal attempt succeeds.
+        self.cmd.group_remove_member.side_effect = [_not_member(), _completed()]
+        result = self.offboard._remove_one("grp.rw", "alice", external=True)
+        self.assertEqual(result, "internal")
+        self.assertEqual(self.cmd.group_remove_member.call_count, 2)
+
+    def test_not_member_in_either_mode(self):
+        self.cmd.group_remove_member.side_effect = [_not_member(), _not_member()]
+        result = self.offboard._remove_one("grp.rw", "alice", external=True)
+        self.assertEqual(result, "not-member")
+
+    def test_no_group(self):
+        self.cmd.group_remove_member.side_effect = _ipa_errors_stub.NotFound("no such group")
+        result = self.offboard._remove_one("ghost.rw", "alice", external=True)
+        self.assertEqual(result, "no-group")
+
+
+class AddOneRealTest(TestCase):
+    """Exercise the REAL _add_one — only the ipalib api boundary is mocked."""
+
+    def setUp(self):
+        from coldfront.plugins.freeipa import offboard
+
+        self.offboard = offboard
+        self.cmd = MagicMock()
+        _ipa_stub.api.Command = self.cmd
+        self.addCleanup(lambda: setattr(_ipa_stub.api, "Command", MagicMock()))
+
+    def test_external_success(self):
+        self.cmd.group_add_member.return_value = _completed()
+        result = self.offboard._add_one("grp.rw", "alice", external=True)
+        self.assertEqual(result, "external")
+        self.cmd.group_add_member.assert_called_once_with("grp.rw", ipaexternalmember=("alice",))
+
+    def test_internal_success(self):
+        self.cmd.group_add_member.return_value = _completed()
+        result = self.offboard._add_one("grp.rw", "bob", external=False)
+        self.assertEqual(result, "internal")
+        self.cmd.group_add_member.assert_called_once_with("grp.rw", user=["bob"])
+
+    def test_already_member(self):
+        self.cmd.group_add_member.return_value = _already_member()
+        result = self.offboard._add_one("grp.rw", "alice", external=True)
+        self.assertEqual(result, "already-member")
+
+    def test_no_group(self):
+        self.cmd.group_add_member.side_effect = _ipa_errors_stub.NotFound("no such group")
+        result = self.offboard._add_one("ghost.rw", "alice", external=True)
+        self.assertEqual(result, "no-group")

--- a/coldfront/plugins/freeipa/tests/test_offboard.py
+++ b/coldfront/plugins/freeipa/tests/test_offboard.py
@@ -152,6 +152,13 @@ class IsExternalMemberTest(TestCase):
         self.assertFalse(self.offboard.is_external_member(u))
 
 
+def _role_suffixed(allocation):
+    """Example group_names_for_allocation override: one attribute value -> two groups."""
+    from coldfront.plugins.freeipa.offboard import _allocation_base_groups
+
+    return {f"{v}{suffix}" for v in _allocation_base_groups(allocation) for suffix in (".rw", ".ro")}
+
+
 class ManagedGroupsForUserTest(TestCase):
     def test_no_allocations(self):
         from coldfront.plugins.freeipa.offboard import managed_groups_for_user
@@ -159,32 +166,39 @@ class ManagedGroupsForUserTest(TestCase):
         u = UserFactory()
         self.assertEqual(managed_groups_for_user(u), set())
 
-    def test_groups_from_single_allocation(self):
+    def test_default_uses_literal_attribute_value(self):
         from coldfront.plugins.freeipa.offboard import managed_groups_for_user
 
         u = UserFactory()
-        _make_allocation(u, "proj1.e.d")
+        _make_allocation(u, "proj1")
         result = managed_groups_for_user(u)
-        self.assertEqual(result, {"proj1.e.d.rw", "proj1.e.d.ro"})
+        self.assertEqual(result, {"proj1"})
 
     def test_dedup_across_allocations(self):
         from coldfront.plugins.freeipa.offboard import managed_groups_for_user
 
         u = UserFactory()
-        _make_allocation(u, "proj1.e.d")
-        _make_allocation(u, "proj1.e.d")  # same base, second allocation
+        _make_allocation(u, "proj1")
+        _make_allocation(u, "proj1")  # same base, second allocation
         result = managed_groups_for_user(u)
-        self.assertEqual(result, {"proj1.e.d.rw", "proj1.e.d.ro"})
+        self.assertEqual(result, {"proj1"})
 
     def test_multiple_allocations(self):
         from coldfront.plugins.freeipa.offboard import managed_groups_for_user
 
         u = UserFactory()
-        _make_allocation(u, "projA.e.d")
-        _make_allocation(u, "projB.e")
+        _make_allocation(u, "projA")
+        _make_allocation(u, "projB")
         result = managed_groups_for_user(u)
-        self.assertIn("projA.e.d.rw", result)
-        self.assertIn("projB.e.ro", result)
+        self.assertEqual(result, {"projA", "projB"})
+
+    def test_group_names_for_allocation_override(self):
+        from coldfront.plugins.freeipa.offboard import managed_groups_for_user
+
+        u = UserFactory()
+        _make_allocation(u, "proj1")
+        result = managed_groups_for_user(u, group_names_for_allocation=_role_suffixed)
+        self.assertEqual(result, {"proj1.rw", "proj1.ro"})
 
 
 class GroupsToKeepTest(TestCase):
@@ -192,34 +206,41 @@ class GroupsToKeepTest(TestCase):
         from coldfront.plugins.freeipa.offboard import groups_to_keep
 
         u = UserFactory()
-        _make_allocation(u, "live.e.d", alloc_status="Active", au_status="Active")
+        _make_allocation(u, "live", alloc_status="Active", au_status="Active")
         result = groups_to_keep(u)
-        self.assertIn("live.e.d.rw", result)
-        self.assertIn("live.e.d.ro", result)
+        self.assertIn("live", result)
 
     def test_removed_au_not_kept(self):
         from coldfront.plugins.freeipa.offboard import groups_to_keep
 
         u = UserFactory()
-        _make_allocation(u, "gone.e.d", alloc_status="Active", au_status="Removed")
+        _make_allocation(u, "gone", alloc_status="Active", au_status="Removed")
         result = groups_to_keep(u)
-        self.assertNotIn("gone.e.d.rw", result)
+        self.assertNotIn("gone", result)
 
     def test_inactive_allocation_not_kept(self):
         from coldfront.plugins.freeipa.offboard import groups_to_keep
 
         u = UserFactory()
-        _make_allocation(u, "expired.e.d", alloc_status="Expired", au_status="Active")
+        _make_allocation(u, "expired", alloc_status="Expired", au_status="Active")
         result = groups_to_keep(u)
-        self.assertNotIn("expired.e.d.rw", result)
+        self.assertNotIn("expired", result)
 
     def test_exclude_allocation_pk(self):
         from coldfront.plugins.freeipa.offboard import groups_to_keep
 
         u = UserFactory()
-        alloc = _make_allocation(u, "proj.e.d", alloc_status="Active", au_status="Active")
+        alloc = _make_allocation(u, "proj", alloc_status="Active", au_status="Active")
         result = groups_to_keep(u, exclude_allocation_pk=alloc.pk)
-        self.assertNotIn("proj.e.d.rw", result)
+        self.assertNotIn("proj", result)
+
+    def test_group_names_for_allocation_override(self):
+        from coldfront.plugins.freeipa.offboard import groups_to_keep
+
+        u = UserFactory()
+        _make_allocation(u, "live", alloc_status="Active", au_status="Active")
+        result = groups_to_keep(u, group_names_for_allocation=_role_suffixed)
+        self.assertEqual(result, {"live.rw", "live.ro"})
 
 
 class PlanOffboardTest(TestCase):
@@ -227,28 +248,37 @@ class PlanOffboardTest(TestCase):
         from coldfront.plugins.freeipa.offboard import plan_offboard
 
         u = UserFactory()
-        _make_allocation(u, "proj.e.d", alloc_status="Active", au_status="Removed")
+        _make_allocation(u, "proj", alloc_status="Active", au_status="Removed")
         targets, kept = plan_offboard(u)
-        self.assertIn("proj.e.d.rw", targets)
+        self.assertIn("proj", targets)
         self.assertEqual(len(kept), 0)
 
     def test_kept_excludes_from_targets(self):
         from coldfront.plugins.freeipa.offboard import plan_offboard
 
         u = UserFactory()
-        _make_allocation(u, "proj.e.d", alloc_status="Active", au_status="Active")
+        _make_allocation(u, "proj", alloc_status="Active", au_status="Active")
         targets, kept = plan_offboard(u)
-        self.assertNotIn("proj.e.d.rw", targets)
-        self.assertIn("proj.e.d.rw", kept)
+        self.assertNotIn("proj", targets)
+        self.assertIn("proj", kept)
 
     def test_targets_sorted(self):
         from coldfront.plugins.freeipa.offboard import plan_offboard
 
         u = UserFactory()
-        _make_allocation(u, "beta.e", alloc_status="Active", au_status="Removed")
-        _make_allocation(u, "alpha.e", alloc_status="Active", au_status="Removed")
+        _make_allocation(u, "beta", alloc_status="Active", au_status="Removed")
+        _make_allocation(u, "alpha", alloc_status="Active", au_status="Removed")
         targets, _ = plan_offboard(u)
         self.assertEqual(targets, sorted(targets))
+
+    def test_group_names_for_allocation_override(self):
+        from coldfront.plugins.freeipa.offboard import plan_offboard
+
+        u = UserFactory()
+        _make_allocation(u, "proj", alloc_status="Active", au_status="Removed")
+        targets, kept = plan_offboard(u, group_names_for_allocation=_role_suffixed)
+        self.assertEqual(set(targets), {"proj.rw", "proj.ro"})
+        self.assertEqual(kept, set())
 
 
 class RemoveUserFromGroupsTest(TestCase):
@@ -362,21 +392,30 @@ class OffboardUserGroupsTaskTest(TestCase):
 
         u = UserFactory()
         with (
-            patch(
-                "coldfront.plugins.freeipa.offboard.plan_offboard", return_value=(["proj.e.d.rw"], set())
-            ) as mock_plan,
+            patch("coldfront.plugins.freeipa.offboard.plan_offboard", return_value=(["proj"], set())) as mock_plan,
             patch("coldfront.plugins.freeipa.offboard.remove_user_from_groups") as mock_rm,
         ):
             offboard_user_groups_task(user_pk=u.pk)
-        mock_plan.assert_called_once_with(u)
-        mock_rm.assert_called_once_with(u, ["proj.e.d.rw"], dry_run=False)
+        mock_plan.assert_called_once_with(u, group_names_for_allocation=None)
+        mock_rm.assert_called_once_with(u, ["proj"], dry_run=False)
+
+    def test_group_names_for_allocation_threaded_through(self):
+        from coldfront.plugins.freeipa.offboard import offboard_user_groups_task
+
+        u = UserFactory()
+        with (
+            patch("coldfront.plugins.freeipa.offboard.plan_offboard", return_value=(["proj.rw"], set())) as mock_plan,
+            patch("coldfront.plugins.freeipa.offboard.remove_user_from_groups"),
+        ):
+            offboard_user_groups_task(user_pk=u.pk, group_names_for_allocation=_role_suffixed)
+        mock_plan.assert_called_once_with(u, group_names_for_allocation=_role_suffixed)
 
     def test_empty_targets_no_remove_call(self):
         from coldfront.plugins.freeipa.offboard import offboard_user_groups_task
 
         u = UserFactory()
         with (
-            patch("coldfront.plugins.freeipa.offboard.plan_offboard", return_value=([], {"proj.e.d.rw"})),
+            patch("coldfront.plugins.freeipa.offboard.plan_offboard", return_value=([], {"proj"})),
             patch("coldfront.plugins.freeipa.offboard.remove_user_from_groups") as mock_rm,
         ):
             offboard_user_groups_task(user_pk=u.pk)


### PR DESCRIPTION
## Problem

The freeipa plugin's group sync (`tasks.remove_user_group`) skips users — e.g. a departed user whose `ProjectUser` was hard-deleted. Those users keep their FreeIPA group membership, and the filesystem access it grants, indefinitely. There is currently no way to revoke a departed user's group access independent of that path.

This is adjacent to the original concern in #172 ("FreeIPA Plugin only adds to groups"): #171 fixed group *sync*, but the fully-departed case (no `AllocationUser` status transition to drive it) remains.

## Approach

New module `coldfront/plugins/freeipa/offboard.py` offboards a user by **capture-and-attempt**:

- **`managed_groups_for_user(user)`** — derive the FreeIPA groups granted by every allocation the user is on. By default, a group is the literal `freeipa_group` allocation attribute value — exactly what `tasks.add_user_group`/`remove_user_group` use as the group name. An optional `group_names_for_allocation(allocation) -> names` callable lets a deployment override this for setups where one attribute value maps to more than one actual group (e.g. a role-based naming scheme layered on top by a downstream plugin); both this function and `groups_to_keep`/`plan_offboard`/`offboard_user_groups_task` accept the same override.
- **`groups_to_keep` / `plan_offboard`** — subtract any group the user still holds via another **Active** allocation (cross-allocation safeguard, mirroring `tasks.remove_user_group`).
- **`remove_user_from_groups` / `add_user_to_groups`** — attempt the change for both internal (`user=`) and AD-trust external (`ipaexternalmember=`) member types; treat *not a member* / *group not found* as harmless no-ops and **never raise**. Each call returns a per-group result record suitable for an audit log and a faithful backout (re-add).
- **`offboard_user_groups_task(user_pk)`** — a `django-q` entry point so the work can run in a worker.

Design notes:

- No import-time side effects; does **not** import `freeipa/tasks.py` (which runs a semaphore read, a sleep, and a possible `sys.exit` at import).
- External-member detection is by the optional `FREEIPA_EXTERNAL_DOMAIN` setting (empty default → all users treated as internal).
- This is a reusable helper; it does not wire itself into any signal, so deployments opt in by calling it (a management command or signal receiver).

## Tests

`coldfront/plugins/freeipa/tests/test_offboard.py` — 40 unit tests covering the pure ORM logic (including the default literal-group-name behaviour and the `group_names_for_allocation` override) and the FreeIPA-calling paths (the `ipalib` API boundary is mocked, so the suite runs without an IPA enrolment), including the external→internal fallback, not-a-member / group-not-found no-ops, and the never-raises guarantee.

```
$ coldfront test coldfront.plugins.freeipa.tests.test_offboard
Ran 40 tests ... OK
```

Ruff `check` and `format` clean. Commits are DCO signed-off.
