### PR TITLE
pyproject: fix Django version in classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license-files = ["LICENSES/*.txt"]
 keywords = ["high-performance-computing", "resource-allocation"]
 classifiers = [
     'Programming Language :: Python :: 3',
-    'Framework :: Django :: 4.2',
+    'Framework :: Django :: 5.2',
     'Topic :: Scientific/Engineering',
     'Topic :: System :: Systems Administration',
     'Topic :: Internet :: WWW/HTTP :: WSGI :: Application',


### PR DESCRIPTION
In [pyproject.yaml](https://github.com/coldfront/coldfront/blob/9323ce60b5faa31c29550c0cc9a48e6abb937ed6/pyproject.toml#L21):

`Framework :: Django :: 4.2` -> `Framework :: Django :: 5.2`