### PR TITLE
allocation change request: dont try to validate nonexistent inputs

### DIFF
--- a/coldfront/core/allocation/tests/test_views.py
+++ b/coldfront/core/allocation/tests/test_views.py
@@ -168,6 +168,9 @@ class AllocationChangeDetailViewTest(AllocationViewBaseTest):
         AllocationAttributeChangeRequest.objects.create(
             allocation_change_request=req4, allocation_attribute=self.quota_attribute, new_value=200
         )
+        AllocationChangeRequestFactory(
+            id=6, allocation=self.allocation, end_date_extension=ALLOCATION_CHANGE_REQUEST_EXTENSION_DAYS[0]
+        )  # deny and then update notes
 
     def test_allocationchangedetailview_access_granted(self):
         response = self.client.get(reverse("allocation-change-detail", kwargs={"pk": 2}))
@@ -248,6 +251,31 @@ class AllocationChangeDetailViewTest(AllocationViewBaseTest):
         alloc_change_req.refresh_from_db()
         self.assertEqual(alloc_change_req.status.name, "Pending")
         self.assertEqual(alloc_change_req.end_date_extension, ALLOCATION_CHANGE_REQUEST_EXTENSION_DAYS[1])
+
+    def test_allocationchangedetailview_post_update_deny_and_then_update_notes(self):
+        """Test that posting to an AllocationChangeDetailView with action=update
+        changes the notes of AllocationChangeRequest(pk=6), after it has been denied already."""
+        note_value_before = "before"
+        note_value_after = "after"
+        # deny
+        response = self.client.post(
+            reverse("allocation-change-detail", kwargs={"pk": 6}),
+            {"action": "deny", "notes": note_value_before},
+            follow=True,
+        )
+        utils.assert_response_success(self, response)
+        alloc_change_req = AllocationChangeRequest.objects.get(pk=6)
+        self.assertEqual(alloc_change_req.status.name, "Denied")
+        self.assertEqual(alloc_change_req.notes, note_value_before)
+        # update notes
+        response = self.client.post(
+            reverse("allocation-change-detail", kwargs={"pk": 6}),
+            {"action": "update", "notes": note_value_after},
+            follow=True,
+        )
+        utils.assert_response_success(self, response)
+        alloc_change_req.refresh_from_db()
+        self.assertEqual(alloc_change_req.notes, note_value_after)
 
 
 class AllocationChangeViewTest(AllocationViewBaseTest):

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -1716,6 +1716,12 @@ class AllocationChangeDetailView(LoginRequiredMixin, UserPassesTestMixin, FormVi
 
             return HttpResponseRedirect(reverse("allocation-change-detail", kwargs={"pk": pk}))
 
+        if action == "update" and allocation_change_obj.status.name != "Pending":
+            allocation_change_obj.notes = notes
+            allocation_change_obj.save()
+            messages.success(request, "Allocation change request updated!")
+            return HttpResponseRedirect(reverse("allocation-change-detail", kwargs={"pk": pk}))
+
         if not allocation_change_form.is_valid() or (allocation_attributes_to_change and not formset.is_valid()):
             for error in allocation_change_form.errors:
                 messages.error(request, error)
@@ -1728,12 +1734,6 @@ class AllocationChangeDetailView(LoginRequiredMixin, UserPassesTestMixin, FormVi
             return HttpResponseRedirect(reverse("allocation-change-detail", kwargs={"pk": pk}))
 
         allocation_change_obj.notes = notes
-
-        if action == "update" and allocation_change_obj.status.name != "Pending":
-            allocation_change_obj.save()
-            messages.success(request, "Allocation change request updated!")
-            return HttpResponseRedirect(reverse("allocation-change-detail", kwargs={"pk": pk}))
-
         form_data = allocation_change_form.cleaned_data
         end_date_extension = form_data.get("end_date_extension")
 


### PR DESCRIPTION
When an allocation change request is not `Pending`, the allocation attribute update ~~forms~~ inputs are hidden from the template:

https://github.com/coldfront/coldfront/blob/da04c2312d8c5961de4091832713c0c6a547c721/coldfront/core/allocation/templates/allocation/allocation_change_detail.html#L139

`AllocationChangeDetailView.post` reconstructs its expected `formset` of `AllocationAttributeUpdateForm` objects, validates it, and then throws an error to the user, regardless of whether or not the inputs for those forms actually exist in `request.POST`:

https://github.com/coldfront/coldfront/blob/da04c2312d8c5961de4091832713c0c6a547c721/coldfront/core/allocation/views.py#L1723

Since the inputs don't exist, an empty string is returned from `request.POST`. If the allocation has an editable numeric attribute, an empty string will fail to validate. So when an admin tries to add a note to a non-pending allocation change request, they get this:

<img width="381" height="95" alt="image" src="https://github.com/user-attachments/assets/ef108e83-ea60-474f-abf7-a623944091d5" />

<details>
<summary>I got this traceback:</summary>

```
File "/srv/prod/venv/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
  response = get_response(request)
File "/srv/prod/venv/lib/python3.12/site-packages/django/contrib/auth/middleware.py", line 133, in __call__
  return self.get_response(request)
File "/srv/prod/venv/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
  response = get_response(request)
File "/srv/prod/venv/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
  response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/srv/prod/venv/lib/python3.12/site-packages/django/views/generic/base.py", line 105, in view
  return self.dispatch(request, *args, **kwargs)
File "/srv/prod/venv/lib/python3.12/site-packages/django/contrib/auth/mixins.py", line 73, in dispatch
  return super().dispatch(request, *args, **kwargs)
File "/srv/prod/venv/lib/python3.12/site-packages/django/contrib/auth/mixins.py", line 135, in dispatch
  return super().dispatch(request, *args, **kwargs)
File "/srv/prod/venv/lib/python3.12/site-packages/django/views/generic/base.py", line 144, in dispatch
  return handler(request, *args, **kwargs)
File "/srv/simon/coldfront/coldfront/core/allocation/views.py", line 1719, in post
  if not allocation_change_form.is_valid() or (allocation_attributes_to_change and not formset.is_valid()):
File "/srv/prod/venv/lib/python3.12/site-packages/django/forms/formsets.py", line 384, in is_valid
  self.errors
File "/srv/prod/venv/lib/python3.12/site-packages/django/forms/formsets.py", line 366, in errors
  self.full_clean()
File "/srv/prod/venv/lib/python3.12/site-packages/django/forms/formsets.py", line 429, in full_clean
  form_errors = form.errors
File "/srv/prod/venv/lib/python3.12/site-packages/django/forms/forms.py", line 201, in errors
  self.full_clean()
File "/srv/prod/venv/lib/python3.12/site-packages/django/forms/forms.py", line 338, in full_clean
  self._clean_form()
File "/srv/prod/venv/lib/python3.12/site-packages/django/forms/forms.py", line 354, in _clean_form
  cleaned_data = self.clean()
File "/srv/simon/coldfront/coldfront/core/allocation/forms.py", line 288, in clean
  allocation_attribute.clean()
File "/srv/simon/coldfront/coldfront/core/allocation/models.py", line 597, in clean
  validator.validate_int()
File "/srv/simon/coldfront/coldfront/core/utils/validate.py", line 22, in validate_int
  self._raise_if_empty()
File "/srv/simon/coldfront/coldfront/core/utils/validate.py", line 18, in _raise_if_empty
  traceback.print_stack(file=sys.stderr)
```

</details>

There is already a conditional that handles an `action==update` to a non-`Pending` allocation change request, where only the `.notes` attribute needs to be changed and nothing else. I have simply moved this conditional up so that it occurs before the validation of the other forms.